### PR TITLE
[SERV-584] Accommodate breaking changes since Solr 4; cleanup

### DIFF
--- a/ucla-prrla/src/app/services/solr.service.ts
+++ b/ucla-prrla/src/app/services/solr.service.ts
@@ -148,7 +148,6 @@ export class SolrService {
             'facet.field=decade&' +
             'facet.field=language_keyword&' +
             'facet.field=rights_keyword&' +
-            'facet.field=collection&' +
             'facet.field=source_keyword&' +
             'facet.field=description_keyword&' +
             'facet.field=identifier_keyword&' +
@@ -596,7 +595,7 @@ export class SolrService {
         let url =
             this.baseURL + 'select' +
             '?q=institutionName:' + encodeURIComponent('"' + universityName + '"') +
-            '&rows=-1' +
+            '&rows=' + (Math.pow(2,31) - 1) +
             '&facet=true' +
             '&facet.field=collectionName' +
             '&facet.sort=count' +

--- a/ucla-prrla/src/app/services/solr.service.ts
+++ b/ucla-prrla/src/app/services/solr.service.ts
@@ -138,7 +138,7 @@ export class SolrService {
             'q=' + encodeURIComponent(SolrService.escapeLucene(search)) + '&' +
             'rows=' + this.pageSize + '&' +
             'start=' + offset + '&' +
-            'wt=json&' +
+            'wt=jsonp&' +
             'sort=' + encodeURI(this.orderBy) + '&' +
             'facet=true&' +
             'facet.field=institutionName&' +
@@ -261,7 +261,7 @@ export class SolrService {
             this.baseURL + 'select' + '?' +
             'q=' + encodeURI('id:' + SolrService.escapeLucene(id)) + '&' +
             'indent=true&' +
-            'wt=json&' +
+            'wt=jsonp&' +
             'json.wrf=JSONP_CALLBACK';
 
         return this._jsonp.get(url).map(data => {
@@ -462,7 +462,7 @@ export class SolrService {
         let url =
             this.baseURL + 'select' + '?' +
             'q=*&' +
-            'wt=json&' +
+            'wt=jsonp&' +
             'sort=institutionName%20asc&' +
             'facet=true&' +
             'rows=0&' +
@@ -507,7 +507,7 @@ export class SolrService {
             this.baseURL + 'select' +
             '?q=prrla_member_title:*' +
             '&rows=0' +
-            '&wt=json' +
+            '&wt=jsonp' +
             '&sort=prrla_member_title%20asc' +
             '&indent=true' +
             '&facet=true' +
@@ -551,7 +551,7 @@ export class SolrService {
         let url =
             this.baseURL + 'select' + '?' +
             'q=*&' +
-            'wt=json&' +
+            'wt=jsonp&' +
             'facet=true&' +
             'rows=0&' +
             'facet.field=collectionName&' +
@@ -602,7 +602,7 @@ export class SolrService {
             '&facet.mincount=1' +
             '&facet.limit=-1' +
             // '&sort=collectionName%20asc' +
-            '&wt=json' +
+            '&wt=jsonp' +
             '&indent=true' +
             '&json.wrf=JSONP_CALLBACK';
 
@@ -644,7 +644,7 @@ export class SolrService {
         let url =
             this.baseURL + 'select' + '?' +
             'q=*&' +
-            'wt=json&' +
+            'wt=jsonp&' +
             'facet=true&' +
             'rows=0&' +
             'facet.field=institutionName&' +
@@ -688,7 +688,7 @@ export class SolrService {
         let url =
             this.baseURL + 'select' +
             '?q=prrla_member_title:' + '"' + encodeURIComponent(name) + '"' +
-            '&wt=json' +
+            '&wt=jsonp' +
             '&indent=true' +
             '&json.wrf=JSONP_CALLBACK';
 


### PR DESCRIPTION
- `rows` no longer supports -1 as a sentinel value
- we never used a facet field called `collection`
- the [corresponding PR to the backend](https://github.com/UCLALibrary/prl-harvester/pull/25) creates a `jsonp` response writer I think should be used instead of the built-in `json` one